### PR TITLE
Discovery helper app

### DIFF
--- a/apps/discovery-helper/README.md
+++ b/apps/discovery-helper/README.md
@@ -1,0 +1,19 @@
+# Discovery helper app
+
+This app improves the printer discovery function for Anycubic Slicer Next when in LAN mode.
+
+## How it works
+
+In some networks, connecting the printer from Anycubic Slicer Next is impossible, even if the printer is reachable over the network by other means.
+
+This happens if a router or switch uses "IGMP snooping" which filters where multicast packets are delivered. The printer listens for a multicast SSDP message from the slicer, but because it is not a member of the SSDP multicast group, the network will not deliver the message to the printer. In order to join the multicast group, the printer has to send a specific IGMP report, but the stock firmware does not do this.
+
+That is where this app comes in. When it starts it will send an IGMP report to add the printer to the SSDP multicast group, allowing it to receive the discovery request.
+
+## Usage
+
+When the app is started, the printer can be connected to from Anycubic Slicer Next. It's important not to wait too long, as the multicast membership can expire after some time.
+
+Once connected, the app is not strictly necessary as long as the printer is listed in the slicer and the IP address stays the same.
+
+If for some reason you waited too long before connecting from the slicer, you can disable and re-enable the app to renew the multicast membership.

--- a/apps/discovery-helper/app.json
+++ b/apps/discovery-helper/app.json
@@ -1,0 +1,14 @@
+{
+    "$version": "1",
+
+    "name": "Discovery helper",
+    "description": "Improves LAN mode discovery of the printer in Anycubic Slicer Next",
+    "version": "1.0",
+    "depends": [],
+
+    "requirements":
+    {
+        "cpu": 0,
+        "memory": 0
+    }
+}

--- a/apps/discovery-helper/app.sh
+++ b/apps/discovery-helper/app.sh
@@ -1,0 +1,59 @@
+source /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+PID_FILE="/tmp/discovery-helper.pid"
+
+status() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE" 2>/dev/null)
+        if [ -n "$PID" ] && ps | grep -q "^ *$PID "; then
+            log "Discovery helper is running with PID: $PID"
+            report_status $APP_STATUS_STARTED
+            return 0
+        fi
+    fi
+    
+    log "Discovery helper is not running"
+    report_status $APP_STATUS_STOPPED
+    return 1
+}
+
+start() {
+    log "Starting discovery helper"
+    nohup python $APP_ROOT/join-multicast.py 2>&1 &
+    PID=$!
+    echo $PID > "$PID_FILE"
+}
+
+stop() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if [ -n "$PID" ]; then
+            log "Stopping discovery helper (PID: $PID)"
+            kill $PID 2>/dev/null || kill -9 $PID 2>/dev/null
+            rm -f "$PID_FILE"
+            log "Stopped discovery helper"
+            return 0
+        fi
+    fi
+    
+    log "Discovery helper not found"
+    rm -f "$PID_FILE"
+    return 0
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop}" >&2
+        exit 1
+        ;;
+esac

--- a/apps/discovery-helper/app.sh
+++ b/apps/discovery-helper/app.sh
@@ -1,45 +1,18 @@
 source /useremain/rinkhals/.current/tools.sh
 
 APP_ROOT=$(dirname $(realpath $0))
-PID_FILE="/tmp/discovery-helper.pid"
 
 status() {
-    if [ -f "$PID_FILE" ]; then
-        PID=$(cat "$PID_FILE" 2>/dev/null)
-        if [ -n "$PID" ] && ps | grep -q "^ *$PID "; then
-            log "Discovery helper is running with PID: $PID"
-            report_status $APP_STATUS_STARTED
-            return 0
-        fi
-    fi
-    
-    log "Discovery helper is not running"
     report_status $APP_STATUS_STOPPED
-    return 1
 }
 
 start() {
     log "Starting discovery helper"
     nohup python $APP_ROOT/join-multicast.py 2>&1 &
-    PID=$!
-    echo $PID > "$PID_FILE"
 }
 
 stop() {
-    if [ -f "$PID_FILE" ]; then
-        PID=$(cat "$PID_FILE")
-        if [ -n "$PID" ]; then
-            log "Stopping discovery helper (PID: $PID)"
-            kill $PID 2>/dev/null || kill -9 $PID 2>/dev/null
-            rm -f "$PID_FILE"
-            log "Stopped discovery helper"
-            return 0
-        fi
-    fi
-    
-    log "Discovery helper not found"
-    rm -f "$PID_FILE"
-    return 0
+    exit 0
 }
 
 case "$1" in

--- a/apps/discovery-helper/join-multicast.py
+++ b/apps/discovery-helper/join-multicast.py
@@ -1,0 +1,42 @@
+import socket
+import struct
+
+# Multicast group for SSDP
+multicast_group = '239.255.255.250'
+interface_ip = '0.0.0.0'
+
+# Create a raw socket for IGMP
+sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_IGMP)
+mreq = struct.pack('4s4s', socket.inet_aton(multicast_group), socket.inet_aton(interface_ip))
+sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+# Create the initial IGMPv2 Membership Report packet
+type = 0x16
+max_resp_time = 0
+checksum = 0
+group_address = socket.inet_aton(multicast_group)
+igmp_header = struct.pack('!BBH4s', type, max_resp_time, checksum, group_address)
+
+def calculate_checksum(data):
+    """Calculates 16-bit one's complement (Internet checksum)"""
+    sum = 0
+    for i in range(0, len(data), 2):
+        if i + 1 >= len(data):
+            sum += data[i] & 0xff
+        else:
+            sum += ((data[i] << 8) & 0xff00) + (data[i+1] & 0xff)
+
+    while (sum >> 16) > 0:
+        sum = (sum & 0xffff) + (sum >> 16)
+
+    return ~sum & 0xffff
+
+# Checksum the packet
+checksum = calculate_checksum(igmp_header)
+igmp_header = struct.pack('!BBH4s', type, max_resp_time, checksum, group_address)
+
+# Send the packet to the multicast group
+sock.sendto(igmp_header, (multicast_group, 0))
+sock.close()
+
+print(f"IGMPv2 Membership Report sent to group {multicast_group}")


### PR DESCRIPTION
On networks that employ IGMP snooping, the stock firmware is unable to receive the multicast requests used for discovery by Anycubic Slicer Next. This is because it does not send an IGMP Membership Report when opening the multicast port.

This app provides a Python script that sends the necessary IGMP packet, making the printer visible to the slicer.

It is possible that Anycubic will fix this in the stock firmware in the future, as I have reported the bug to them. But until then this should be a convenient workaround.
