### PR TITLE
add nfs mount app

### DIFF
--- a/apps/nfs-mount/README.md
+++ b/apps/nfs-mount/README.md
@@ -1,0 +1,29 @@
+# NFS Mount
+
+Replace local gcode storage with NFS to offload I/O operations from the printer's storage.
+
+## Features
+
+- Mounts NFS shares to replace local gcode storage
+- Supports both `/userdata/app/gk/printer_data/gcodes` and `/useremain/app/gk/gcodes` directories
+- Automatically unmounts and remounts local filesystems when starting/stopping
+- Configurable NFS server, port, and share path
+- Skips mounting if using placeholder defaults (requires configuration)
+
+## Configuration
+
+- `server`: NFS server IP address (default: 192.168.1.100)
+- `port`: NFS port (default: 2049)
+- `share`: NFS share path (default: /mnt/share)
+
+## Installation
+
+1. Clone this repository
+2. Configure your NFS server details in `apps/nfs-mount/app.json`
+3. Create build directory: `mkdir -p build/dist`
+4. Build the SWU package for your printer model:
+   ```bash
+   export KOBRA_MODEL_CODE="YOUR_MODEL"  # K2P, K3, KS1, or K3M
+   docker run --rm -e KOBRA_MODEL_CODE="$KOBRA_MODEL_CODE" -v $(pwd)/build:/build -v $(pwd)/apps:/apps ghcr.io/jbatonnet/rinkhals/build /bin/bash -c "chmod +x /build/build-swu.sh && /build/build-swu.sh apps/nfs-mount"
+   ```
+5. Install the SWU file following the [official Rinkhals installation guide](https://jbatonnet.github.io/Rinkhals/Rinkhals/installation-and-firmware-updates/)

--- a/apps/nfs-mount/app.json
+++ b/apps/nfs-mount/app.json
@@ -1,0 +1,25 @@
+{
+    "$version": "1",
+
+    "name": "NFS Mount",
+    "description": "Replace local gcode storage with NFS to offload I/O",
+    "version": "0.1",
+
+    "properties": {
+        "server": {
+            "display": "NFS Server",
+            "type": "string",
+            "default": "192.168.1.100"
+        },
+        "port": {
+            "display": "NFS Port",
+            "type": "number",
+            "default": "2049"
+        },
+        "share": {
+            "display": "NFS Share Path",
+            "type": "string",
+            "default": "/mnt/share"
+        }
+    }
+}

--- a/apps/nfs-mount/app.sh
+++ b/apps/nfs-mount/app.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+source /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+APP_NAME=$(basename $APP_ROOT)
+
+status() {
+    # Check if both mount points are mounted
+    if mountpoint -q "/userdata/app/gk/printer_data/gcodes" 2>/dev/null && mountpoint -q "/useremain/app/gk/gcodes" 2>/dev/null; then
+        report_status $APP_STATUS_STARTED "NFS mounted"
+    else
+        report_status $APP_STATUS_STOPPED
+    fi
+}
+
+start() {
+    stop
+    
+    SERVER=$(get_app_property $APP_NAME server)
+    PORT=$(get_app_property $APP_NAME port)
+    SHARE=$(get_app_property $APP_NAME share)
+    
+    # Skip if using placeholder defaults
+    if [ "$SERVER" = "192.168.1.100" ] && [ "$SHARE" = "/mnt/share" ]; then
+        log "NFS mount skipped: using placeholder defaults"
+        exit 0
+    fi
+    
+    log "Starting NFS mount: $SERVER:$SHARE -> /userdata/app/gk/printer_data/gcodes and /useremain/app/gk/gcodes"
+    
+    # Create mount points if they don't exist
+    mkdir -p "/userdata/app/gk/printer_data/gcodes"
+    mkdir -p "/useremain/app/gk/gcodes"
+    
+    # Force unmount existing mounts
+    umount -f "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+    umount -f "/useremain/app/gk/gcodes" 2>/dev/null
+    
+    # Mount the NFS share to first location
+    mount -o port=$PORT,nolock,proto=tcp -t nfs "$SERVER:$SHARE" "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+    
+    if [ $? -eq 0 ]; then
+        # Bind mount to second location
+        mount --bind "/userdata/app/gk/printer_data/gcodes" "/useremain/app/gk/gcodes" 2>/dev/null
+        
+        if [ $? -eq 0 ]; then
+            log "NFS mount successful: $SERVER:$SHARE -> both locations"
+        else
+            log "Bind mount failed, unmounting NFS"
+            umount -f "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+            # Remount original ext4 mount on failure (only userdata location)
+            mount -t ext4 -o rw,relatime /dev/block/by-name/useremain "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+            exit 1
+        fi
+    else
+        log "NFS mount failed: $SERVER:$SHARE -> /userdata/app/gk/printer_data/gcodes"
+        # Remount original ext4 mount on failure (only userdata location)
+        mount -t ext4 -o rw,relatime /dev/block/by-name/useremain "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+        exit 1
+    fi
+}
+
+stop() {
+    log "Stopping NFS mount: both locations"
+    
+    # Force unmount both locations (in reverse order due to bind mount)
+    umount -f "/useremain/app/gk/gcodes" 2>/dev/null
+    umount -f "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+    
+    # Remount original ext4 mount (only userdata location)
+    mount -t ext4 -o rw,relatime /dev/block/by-name/useremain "/userdata/app/gk/printer_data/gcodes" 2>/dev/null
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Basically, embedded storage is pretty fragile and not very generous in terms of IO throughput and neither in endurance. I thought that leveraging Linux's NFS facilities to offload storage to a more powerful machine could be useful in practice to reduce nozzle mcu timer too close errors. If not that, then it certainly helps with longevity of the onboard storage.

I've been using this now for the past week, no issues to report but with the deletion of the ethernet drivers in the KS1 I don't know how useful this will be. So far, NFS over WiFi is proving alright, but a solid connection is mandated, YMMV.